### PR TITLE
Adding a MakeFile infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ lia.cache
 nia.cache
 nlia.cache
 nra.cache
+
+Makefile.coq
+
+Makefile.coq.conf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Inspired from https://github.com/palmskog/coq-program-verification-template
+
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
+
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
+
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,3 @@
+-R theories PartialFun
+
+theories/PartialFun.v


### PR DESCRIPTION
The Makefile is taken from the standard template given [here](https://github.com/palmskog/coq-program-verification-template).