### PR TITLE
Add monad notations

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,5 @@
 -R theories PartialFun
 
+theories/Monad.v
 theories/PartialFun.v
 theories/Examples.v

--- a/theories/Examples.v
+++ b/theories/Examples.v
@@ -1,8 +1,9 @@
 From Equations Require Import Equations.
 From Coq Require Import Utf8 List Arith Lia.
-From PartialFun Require Import PartialFun.
+From PartialFun Require Import PartialFun Monad.
 
 Import ListNotations.
+Import MonadNotations.
 
 Set Default Goal Selector "!".
 Set Equations Transparent.
@@ -12,7 +13,7 @@ Set Universe Polymorphism.
 
 Equations div : ∇ (p : nat * nat), nat :=
   div (0, m) := ret 0 ;
-  div (n, m) := q ← rec (n - m, m) ;; ret (S q).
+  div (n, m) := S <*> rec (n - m, m).
 
 Equations test_div : ∇ (p : nat * nat), bool :=
   test_div (n, m) := q ← call div (n, m) ;; ret (q * m =? n).
@@ -129,9 +130,9 @@ Fail Equations eval (u : term) (π : stack) : term :=
 (* Notice the partial arrow "⇀" *)
 Equations eval : term * stack ⇀ term :=
   eval (tVar n, π) := ret (zip (tVar n) π) ;
-  eval (tLam t, sApp u π) := v ← rec (subst t u, π) ;; ret v ;
-  eval (tLam t, π) := v ← rec (t, sLam π) ;; ret v ;
-  eval (tApp u v, π) := w ← rec (u, sApp v π) ;; ret w.
+  eval (tLam t, sApp u π) := rec (subst t u, π) ;
+  eval (tLam t, π) := rec (t, sLam π) ;
+  eval (tApp u v, π) := rec (u, sApp v π).
 
 (* We get the fueled and wf versions for free *)
 

--- a/theories/Monad.v
+++ b/theories/Monad.v
@@ -1,0 +1,53 @@
+(* (Yet another) description of monads *)
+
+From Equations Require Import Equations.
+From Coq Require Import Utf8 List Arith Lia.
+Import ListNotations.
+
+Set Default Goal Selector "!".
+Set Equations Transparent.
+Set Universe Polymorphism.
+
+Class Monad (M : Type → Type) := {
+  ret : ∀ A, A → M A ;
+  bind : ∀ A B, M A → (A → M B) → M B
+}.
+
+Arguments ret {M _ A}.
+Arguments bind {M _ A B}.
+
+Definition map {M} `{Monad M} {A B} (f : A → B) (m : M A) : M B :=
+  bind m (λ x, ret (f x)).
+
+Module MonadNotations.
+
+  Declare Scope monad_scope.
+  Delimit Scope monad_scope with monad.
+
+  Open Scope monad_scope.
+
+  Notation "c >>= f" :=
+    (bind c f)
+    (at level 50, left associativity) : monad_scope.
+
+  Notation "x ← e ;; f" :=
+    (bind e (λ x, f))
+    (at level 100, e at next level, right associativity)
+    : monad_scope.
+
+  Notation "' pat ← e ;; f" :=
+    (bind e (λ pat, f))
+    (at level 100, e at next level, right associativity, pat pattern)
+    : monad_scope.
+
+  Notation "e ;; f" :=
+    (bind e (λ _, f))
+    (at level 100, right associativity)
+    : monad_scope.
+
+  Notation "f '<*>' m" :=
+    (map f m)
+    (at level 50, left associativity)
+    : monad_scope.
+
+End MonadNotations.


### PR DESCRIPTION
I added a module for monad notations and a class so that one can right more idiomatic code. I hope it is easily overridden by one's own Monad class + notations.

@MevenBertrand can you check it satisfies your needs? (No hurry though.)