### PR TITLE
Making the functional induction case for `call` weaker

### DIFF
--- a/theories/Examples.v
+++ b/theories/Examples.v
@@ -65,7 +65,7 @@ Proof.
     - intuition lia.
   }
   intros n m [v hd].
-  refine (funind_graph _ _ _ (_,_) _ h _ _). all: eauto.
+  refine (funind_graph h (_,_) _ _ _). all: eauto.
 Qed.
 
 Lemma test_div_domain :
@@ -320,11 +320,11 @@ Lemma conv_sound :
 Proof.
   intros [u v] _. simpl.
   eexists _, _. splits.
-  1: apply eval_sound.
+  2: eapply (funind_graph eval_sound).
   1: simpl ; auto.
   simpl. intros u' hu.
   eexists _, _. splits.
-  1: apply eval_sound.
+  2: eapply (funind_graph eval_sound).
   1: simpl ; auto.
   simpl. intros v' hv e.
   exists u', v'.


### PR DESCRIPTION
In the current version of `orec_ind_step`, in the case of a `call`, we demand that a pre/post condition pair to be established by `funind` on the called function. I claim that this is somewhat too strong. In practice, I hit this when I proved two different `funind` for reduction (one asserting that the reduction function implies reduction, and the other that the reduct is a whnf), as they are separate. But now I cannot use both at the same time in another function calling reduction.

There are probably multiple ways to tackle this. The one I propose simply swaps `funind` for a pre/post condition pair, that a user is establish as they please (using `funind`, a combination of multiple ones, combined with logical pre and post reasoning…). But feel free to pick another one or amend this one if you don't like it :)

This makes me think that maybe we'd want some support for Hoare-style triples to handle these pre/post conditions?