### PR TITLE
Functional induction extended to Type and more general

### DIFF
--- a/theories/Examples.v
+++ b/theories/Examples.v
@@ -320,14 +320,9 @@ Lemma conv_sound :
   funind conv (λ _, True) (λ '(u, v) b, b = true → isconv u v).
 Proof.
   intros [u v] _. simpl.
-  eexists _, _. splits.
-  1: apply eval_sound.
-  1: simpl ; auto.
-  simpl. intros u' hu.
-  eexists _, _. splits.
-  1: apply eval_sound.
-  1: simpl ; auto.
-  simpl. intros v' hv e.
+  intros u' hu v' hv e.
+  funind eval_sound in hu.
+  funind eval_sound in hv.
   exists u', v'.
   intuition assumption.
 Qed.


### PR DESCRIPTION
Before, as @MevenBertrand noticed, it was requiring an invariant on called functions which was overly restrictive. This PR also extends it to Type with `funrect`.

As a bonus, we now have tactics `funind foo in h` and `funind foo in h as n` to apply `funind` and `funrect` automatically in hypotheses.

Should subsume and fix #4.