### PR TITLE
Export less typeclasses hints for performance

### DIFF
--- a/theories/Monad.v
+++ b/theories/Monad.v
@@ -14,6 +14,7 @@ Class Monad (M : Type → Type) := {
   bind : ∀ A B, M A → (A → M B) → M B
 }.
 
+#[global] Hint Mode Monad ! : typeclass_instances.
 Arguments ret {M _ A}.
 Arguments bind {M _ A B}.
 
@@ -36,14 +37,29 @@ Module MonadNotations.
     (at level 100, e at next level, right associativity)
     : monad_scope.
 
+  Notation "x ← e ;;[ M ] f" :=
+      (bind (M:=M) e (λ x, f))
+      (at level 100, e at next level, M at level 50, right associativity)
+      : monad_scope.
+
   Notation "' pat ← e ;; f" :=
     (bind e (λ pat, f))
     (at level 100, e at next level, right associativity, pat pattern)
     : monad_scope.
 
+  Notation "' pat ← e ;;[ M ] f" :=
+    (bind (M:=M) e (λ pat, f))
+    (at level 100, e at next level, M at level 50, right associativity, pat pattern)
+    : monad_scope.
+
   Notation "e ;; f" :=
     (bind e (λ _, f))
     (at level 100, right associativity)
+    : monad_scope.
+
+  Notation "e ;;[ M ] f" :=
+    (bind (M:=M) e (λ _, f))
+    (at level 100, M at level 50, right associativity)
     : monad_scope.
 
   Notation "f '<*>' m" :=

--- a/theories/MonadExn.v
+++ b/theories/MonadExn.v
@@ -25,13 +25,16 @@ Definition exn_bind {E A B} (c : exn E A) (f : A → exn E B) :=
   | exception e => exception e
   end.
 
-(* #[export] Instance *) Definition MonadExn {E} : Monad (exn E) := {|
+#[export] Typeclasses Opaque exn_bind.
+Opaque exn_bind.
+
+Definition MonadExn {E} : Monad (exn E) := {|
   ret A x := success x ;
   bind A B c f := exn_bind c f
 |}.
 
 (* Exception monad transformer *)
-(* #[export] Instance *) Definition MonadExnT {E M} `{Monad M} : Monad (λ A, M (exn E A)) := {|
+Definition MonadExnT {E M} `{Monad M} : Monad (λ A, M (exn E A)) := {|
   ret A x := ret (success x) ;
   bind A B c f := bind (M := M) c (λ x,
     match x with
@@ -47,14 +50,31 @@ Class MonadRaise E (M : Type → Type) := {
 
 Arguments raise {E M _ A} e.
 
-#[export] Instance MonadRaiseExnT {E M} `{Monad M} : MonadRaise E (λ A, M (exn E A)) := {|
+#[export] Hint Mode MonadRaise ! ! : typeclass_instances.
+
+Definition MonadRaiseExn {E} : MonadRaise E (exn E) :=
+  {| raise := @exception E |}.
+
+Definition MonadRaiseExnT {E M} `{Monad M} : MonadRaise E (λ A, M (exn E A)) := {|
   raise A e := ret (exception e)
 |}.
 
-#[export] Instance OrecEffectExn E : OrecEffect (exn E).
-Proof.
-  constructor.
-  intros I H A B. apply MonadExnT.
+Definition OrecEffectExn E : OrecEffect (exn E). 
+Proof. 
+  constructor; intros.
+  apply MonadExnT.
 Defined.
 
-#[export] Existing Instance combined_monad.
+Definition OrecEffectExnRaise E I `{CallTypes I} A B: MonadRaise E (combined_orec (exn E) I A B) :=
+{| 
+  raise A e := ret (exception e)
+|}.
+
+Module ExportInstance.
+  #[export]Existing Instance MonadExn | 5.
+  #[export]Existing Instance MonadExnT.
+  #[export]Existing Instance MonadRaiseExn.
+  #[export]Existing Instance MonadRaiseExnT.
+  #[export]Existing Instance OrecEffectExn.
+  #[export]Existing Instance OrecEffectExnRaise.
+End ExportInstance.


### PR DESCRIPTION
This PR adds Hint Modes to every typeclasses and tries not to export most instances by default (a module is provided instead )
CallTypes and CallableProps are employed instead of Callable (not sure this was really worth changing in the end).