### PR TITLE
Fix notations for compatibility with Coq 8.20

### DIFF
--- a/theories/Examples.v
+++ b/theories/Examples.v
@@ -121,7 +121,7 @@ Section Split.
   Let f := true.
   Let g := false.
 
-  Equations try_split : ∇ (n : nat), I ⇒ nat :=
+  Equations try_split : ∇ (n : nat), [ I ]⇒ nat :=
     try_split n :=
       m ← ext_call f n ;;
       ext_call g tt ;;
@@ -533,7 +533,7 @@ Inductive error :=
 
 #[local] Existing Instance combined_monad.
 
-Equations ediv : ∇ (p : nat * nat), exn error ♯ nat :=
+Equations ediv : ∇ (p : nat * nat), [exn error] nat :=
   ediv (n, 0) := raise DivisionByZero ;
   ediv (0, m) := ret 0 ;
   ediv (n, m) := S <*> rec (n - m, m).
@@ -615,15 +615,15 @@ Definition eff_call {A B C F} f `{PFun F f} (x : psrc f) `{OrecLift A B C (ptgt 
   orec PPFun A B C :=
   lift_call f x orec_lift.
 
-Equations test_ediv : ∇ (p : nat * nat), exn error ♯ bool :=
+Equations test_ediv : ∇ (p : nat * nat), [exn error] bool :=
   test_ediv (n, m) := q ← call ediv (n, m) ;; ret (q * m =? n).
 
 (* #[local]
-Hint Extern 0 (Monad (orec PPFun ?A ?B (ptgt ?f ?x))) => 
-  let R := eval cbn in (ptgt f x) in exact (_ : Monad (orec PPFun A B R)) 
+Hint Extern 0 (Monad (orec PPFun ?A ?B (ptgt ?f ?x))) =>
+  let R := eval cbn in (ptgt f x) in exact (_ : Monad (orec PPFun A B R))
   : typeclass_instances. *)
 
-Equations compare_div : ∇ (p : nat * nat), exn error ♯ bool :=
+Equations compare_div : ∇ (p : nat * nat), [exn error] bool :=
   compare_div (n, m) :=
     q ← eff_call ediv (n, m) ;;[combined_orec _ _ _ _]
     q' ← eff_call div (n, m) ;;

--- a/theories/PartialFun.v
+++ b/theories/PartialFun.v
@@ -151,7 +151,7 @@ Fixpoint _bind {I} `{CallTypes I} {A B C D} (c : orec I A B C) (f : C → orec I
 #[export] Typeclasses Opaque _bind.
 Opaque _bind.
 
-Notation "∇ x , I ⇒ B" :=
+Notation "∇ x , [ I ]⇒ B" :=
   (∀ x, orec I _ (λ x, B%type) B)
   (x binder, at level 200).
 
@@ -165,7 +165,7 @@ Notation "∇ x , I ⇒ B" :=
 
 Section Lib.
 
-  Context {I} `{CT : CallTypes I} `{!CallableProps CT} {A B} (f : ∇ (x : A), I ⇒ B x).
+  Context {I} `{CT : CallTypes I} `{!CallableProps CT} {A B} (f : ∇ (x : A), [I]⇒ B x).
 
   Inductive orec_graph {a} : orec I A B (B a) → B a → Prop :=
   | ret_graph :
@@ -907,7 +907,7 @@ Defined.
   CallableSplit _ _ CallablePropsPPFun.
 
 Notation "∇ x , B" :=
-  (∇ x, PPFun ⇒ B)
+  (∇ x, [PPFun]⇒ B)
   (x binder, at level 200).
 
 Notation "A ⇀ B" :=
@@ -915,7 +915,7 @@ Notation "A ⇀ B" :=
   (at level 199).
 
 (* We can provide an instance for all partial functions defined as above. *)
-#[local, refine] Instance pfun_gen A B {I} `{CT:CallTypes I, !CallableProps CT} (f : ∇ (x : A), I ⇒ B x) : PFun f := {|
+#[local, refine] Instance pfun_gen A B {I} `{CT:CallTypes I, !CallableProps CT} (f : ∇ (x : A), [I]⇒ B x) : PFun f := {|
   psrc := A ;
   ptgt := B ;
   pgraph := graph f ;
@@ -964,13 +964,15 @@ Class OrecEffect M := { combined_monad : forall I `{_ : CallTypes I} A B, Monad 
 
 (* Typeclasses Opaque combined. *)
 
-Notation "∇ x , I ⇒ M ♯ B" :=
+Notation "∇ x , [ I ]⇒[ M ] B" :=
   (∀ x, combined_orec M I _ (λ x, M%function B%type) B)
   (x binder, at level 200).
 
-Notation "∇ x , M ♯ B" :=
-  (∀ x, combined_orec M PPFun _ (λ x, M%function B%type) B)
+Notation "∇ x , [ M ] B" := (∇ x, [PPFun]⇒[ M ] B)
+  (* (∀ x, combined_orec M PPFun _ (λ x, M%function B%type) B) *)
   (x binder, at level 200).
+
+
 
 (* Useful tactics *)
 
@@ -1011,7 +1013,7 @@ Module PFUnInstances.
 
   (* PFun instance for effectful partial functions *)
   #[export] Instance pfun_eff_gen
-    A B E `{Monad (combined_orec E PPFun A B)} (f : ∇ (x : A), E ♯ B x) : PFun f :=
+    A B E `{Monad (combined_orec E PPFun A B)} (f : ∇ (x : A), [ E ] B x) : PFun f :=
     pfun_gen A (λ x, E (B x)) f.
 
 End PFUnInstances.

--- a/theories/PartialFun.v
+++ b/theories/PartialFun.v
@@ -159,8 +159,8 @@ Notation "∇ x , I ⇒ B" :=
 #[local] Notation "⟨ x ⟩" := (exist _ x _) (only parsing).
 #[local] Notation "⟨ x | h ⟩" := (exist _ x h).
 
-#[local] Notation "t .1" := (projT1 t) (at level 20).
-#[local] Notation "t .2" := (projT2 t) (at level 20).
+#[local] Notation "t .1" := (projT1 t).
+#[local] Notation "t .2" := (projT2 t).
 #[local] Notation "( x ; y )" := (existT _ x y).
 
 Section Lib.
@@ -958,7 +958,7 @@ Definition combined_orec (M : Type → Type) I `{CallTypes I} A B C :=
 
 #[export] Typeclasses Opaque combined_orec.
 
-Class OrecEffect M := { combined_monad : forall I `{_ : CallTypes I} A B, Monad (combined_orec M I A B) }. 
+Class OrecEffect M := { combined_monad : forall I `{_ : CallTypes I} A B, Monad (combined_orec M I A B) }.
 #[global] Hint Mode OrecEffect ! : typeclass_instances.
 
 


### PR DESCRIPTION
Various notations seem to be breaking in the Coq 8.20 version.
- The notations `.1` and `.2` for projections on sigma types seems to be reserved at level 1 instead of 20 by the stdlib now; changing their levels to the default one fixed by the stdlib seems to work fine in subsequent developments (logrel-coq).
- The notations for partial functions with `∇` are mostly broken, probably due to a new way to factor precedences. I propose the following changes that are open to standard syntactic bikeshedding: 
  + `∇ x, I ⇒ B` ⤳ `∇ x, [I]⇒ B`  
  + `∇ x, I ⇒ M ♯ B` ⤳ `∇ x, [I]⇒[M] B`
  + `∇ x, M ♯ B` ⤳ `∇ x, [M] B`